### PR TITLE
Creates Plan#should_retain and calls services for validation

### DIFF
--- a/lib/snapshot_manager.rb
+++ b/lib/snapshot_manager.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class SnapshotManager
+module SnapshotManager
   def self.ping = :pong
 end

--- a/lib/snapshot_manager/plan.rb
+++ b/lib/snapshot_manager/plan.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SnapshotManager
+  module Plan
+    def self.should_retain(plan, date)
+      Plan.const_get(plan)::RetentionValidationService.new(date).call
+    end
+  end
+end

--- a/lib/snapshot_manager/plan/beginner/retention_validation_service.rb
+++ b/lib/snapshot_manager/plan/beginner/retention_validation_service.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'snapshot_manager/plan'
+
+module SnapshotManager::Plan::Beginner
+  class RetentionValidationService
+    def initialize(date)
+      @date = date
+    end
+
+    def call
+      Date.parse(@date) >= (Date.today - 42)
+    end
+  end
+end

--- a/spec/lib/snapshot_manager/plan/beginner/service_spec.rb
+++ b/spec/lib/snapshot_manager/plan/beginner/service_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'date'
+require_relative '../../../../../lib/snapshot_manager/plan/beginner/retention_validation_service'
+
+describe SnapshotManager::Plan::Beginner::RetentionValidationService do
+  describe '#call' do
+    subject { described_class.new(date).call }
+
+    context 'and daily retain date is expired' do
+      let(:daily_retain_date) { 42 }
+      let(:date) { (Date.today - daily_retain_date - 1).to_s }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/lib/snapshot_manager/plan_spec.rb
+++ b/spec/lib/snapshot_manager/plan_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'date'
+require_relative '../../../lib/snapshot_manager/plan'
+
+describe SnapshotManager::Plan do
+  describe '#should_retain' do
+    subject { described_class.should_retain(plan, date) }
+
+    let(:date) { Date.today.to_s }
+
+    context 'when plan is Beginner' do
+      let(:plan) { 'Beginner' }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to creates the initial structure for should_retain plan snapshots validation.

- It creates a module of Plan and Plan::Beginner;
- it creates a RetentionValidationService for Beginner;
- it creates Plan#should_retain that calls the respective plans validation services