### PR TITLE
Fix Pro and Ultra Plans Retention Validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'rspec'
 gem 'solargraph'
+gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       yard (~> 0.9, >= 0.9.24)
     thor (1.2.2)
     tilt (2.2.0)
+    timecop (0.9.8)
     unicode-display_width (2.4.2)
     yard (0.9.34)
 
@@ -82,6 +83,7 @@ PLATFORMS
 DEPENDENCIES
   rspec
   solargraph
+  timecop
 
 BUNDLED WITH
    2.4.20

--- a/README.md
+++ b/README.md
@@ -37,28 +37,51 @@ To use the Snapshot Manager Retention Validation, you can call the `SnapshotMana
 
 It will determine whether the snapshot for that date should be retained (returns true) or deleted (returns false) according to the rules of the selected backup plan.
 
-Example Usage:
+Example Usage (let's pretend today is 2023/10/03):
 
 ```ruby
+today = Date.today
+
 SnapshotManager.should_retain("Beginner", "2023/01/23")
 => false
 
-SnapshotManager.should_retain("Beginner", Date.today.to_s)
+SnapshotManager.should_retain("Beginner", "2023/10/03")
 => true
 
-SnapshotManager.should_retain("Pro", "2022/01/23")
+SnapshotManager.should_retain("Pro", "2023/01/23")
 => false
 
-SnapshotManager.should_retain("Pro", Date.today.to_s)
+SnapshotManager.should_retain("Pro", "2023/01/31")
+=> true
+
+SnapshotManager.should_retain("Pro", "2023/10/03")
 => true
 
 SnapshotManager.should_retain("Ultra", "2000/01/23")
 => false
 
-SnapshotManager.should_retain("Ultra", Date.today.to_s)
+SnapshotManager.should_retain("Ultra", "2015/12/31")
+=> false
+
+SnapshotManager.should_retain("Ultra", "2016/12/30")
+=> false
+
+SnapshotManager.should_retain("Ultra", "2016/11/30")
+=> false
+
+SnapshotManager.should_retain("Ultra", "2023/01/23")
+=> false
+
+SnapshotManager.should_retain("Ultra", "2016/12/31")
 => true
 
-SnapshotManager.should_retain("InvalidPlan", Date.today.to_s)
+SnapshotManager.should_retain("Ultra", "2023/01/31")
+=> true
+
+SnapshotManager.should_retain("Ultra", "2023/10/03")
+=> true
+
+SnapshotManager.should_retain("InvalidPlan", "2023/10/03")
 => "The plan InvalidPlan is not valid. Valid plans are: [:Pro, :Beginner, :Ultra]"
 
 SnapshotManager.should_retain("Beginner", "invalid date format")

--- a/lib/snapshot_manager/plan.rb
+++ b/lib/snapshot_manager/plan.rb
@@ -6,6 +6,8 @@ module SnapshotManager
     MONTHLY_RETAIN_VALUE = 12
     YEARLY_RETAIN_VALUE = 7
 
+    LAST_DAY_OF_THE_MONTH = -1
+
     def self.validate_retention(plan, date)
       Plan.const_get(plan)::RetentionValidationService.new(date).call
     rescue NameError

--- a/lib/snapshot_manager/plan/beginner/retention_validation_service.rb
+++ b/lib/snapshot_manager/plan/beginner/retention_validation_service.rb
@@ -14,10 +14,14 @@ module SnapshotManager::Plan::Beginner
     end
 
     private def validate_retention
-      @date >= retain_date
+      validate_beginner_plan
     end
 
-    private def retain_date
+    private def validate_beginner_plan
+      @date >= daily_retain_date
+    end
+
+    private def daily_retain_date
       Date.today.prev_day(SnapshotManager::Plan::DAILY_RETAIN_VALUE)
     end
   end

--- a/lib/snapshot_manager/plan/pro/retention_validation_service.rb
+++ b/lib/snapshot_manager/plan/pro/retention_validation_service.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 require 'date'
-require 'snapshot_manager/plan'
+require 'snapshot_manager/plan/beginner/retention_validation_service'
+require_relative '../../plan'
 
 module SnapshotManager::Plan::Pro
   class RetentionValidationService
+    include SnapshotManager::Plan
+
     def initialize(date)
       @date = Date.parse(date)
+      @raw_date = date
     end
 
     def call
@@ -14,14 +18,29 @@ module SnapshotManager::Plan::Pro
     end
 
     private def validate_retention
-      @date >= retain_date
+      validate_beginner_plan || validate_pro_plan
     end
 
-    private def retain_date
-      Date
-        .today
-        .prev_month(SnapshotManager::Plan::MONTHLY_RETAIN_VALUE)
-        .prev_day(SnapshotManager::Plan::DAILY_RETAIN_VALUE)
+    private def validate_beginner_plan
+      Beginner::RetentionValidationService.new(@raw_date).call
+    end
+
+    private def validate_pro_plan
+      monthly_retain_dates.include?(@date)
+    end
+
+    private def monthly_retain_dates
+      MONTHLY_RETAIN_VALUE.times.map do |previous_month_ago|
+        previous_month_ago += 1
+
+        last_day_of_previous_month_ago(previous_month_ago)
+      end
+    end
+
+    private def last_day_of_previous_month_ago(previous_month_ago)
+      previous_month = Date.today.prev_month(previous_month_ago)
+
+      Date.new(previous_month.year, previous_month.month, LAST_DAY_OF_THE_MONTH)
     end
   end
 end

--- a/lib/snapshot_manager/plan/ultra/retention_validation_service.rb
+++ b/lib/snapshot_manager/plan/ultra/retention_validation_service.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 require 'date'
-require 'snapshot_manager/plan'
+require 'snapshot_manager/plan/pro/retention_validation_service'
+require_relative '../../plan'
 
 module SnapshotManager::Plan::Ultra
   class RetentionValidationService
+    include SnapshotManager::Plan
+
     def initialize(date)
       @date = Date.parse(date)
+      @raw_date = date
     end
 
     def call
@@ -14,14 +18,29 @@ module SnapshotManager::Plan::Ultra
     end
 
     private def validate_retention
-      @date >= retain_date
+      validate_pro_plan || validate_ultra_plan
     end
 
-    private def retain_date
-      Date
-        .today.prev_year(SnapshotManager::Plan::YEARLY_RETAIN_VALUE)
-        .prev_month(SnapshotManager::Plan::MONTHLY_RETAIN_VALUE)
-        .prev_day(SnapshotManager::Plan::DAILY_RETAIN_VALUE)
+    private def validate_pro_plan
+      Pro::RetentionValidationService.new(@raw_date).call
+    end
+
+    private def validate_ultra_plan
+      yearly_retain_dates.include?(@date)
+    end
+
+    private def yearly_retain_dates
+      YEARLY_RETAIN_VALUE.times.map do |previous_year_ago|
+        previous_year_ago += 1
+
+        last_day_of_previous_year_ago(previous_year_ago)
+      end
+    end
+
+    private def last_day_of_previous_year_ago(previous_year_ago)
+      previous_year = Date.today.prev_year(previous_year_ago)
+
+      Date.new(previous_year.year, 12, 31)
     end
   end
 end

--- a/spec/lib/snapshot_manager/plan/beginner/retention_validation_service_spec.rb
+++ b/spec/lib/snapshot_manager/plan/beginner/retention_validation_service_spec.rb
@@ -7,20 +7,22 @@ describe SnapshotManager::Plan::Beginner::RetentionValidationService do
   describe '#call' do
     subject { described_class.new(date).call }
 
-    context 'when retain date is expired' do
-      let(:date) { Date.today.prev_day(daily_retain_value + 1).to_s }
+    let(:date) { Date.today.prev_day(days_ago).to_s }
+
+    context 'when daily retain date is expired' do
+      let(:days_ago) { daily_retain_value + 1 }
 
       it { is_expected.to be_falsey }
     end
 
-    context 'when retain date is today' do
-      let(:date) { Date.today.prev_day(daily_retain_value).to_s }
+    context 'when daily retain date is today' do
+      let(:days_ago) { daily_retain_value }
 
       it { is_expected.to be_truthy }
     end
 
-    context 'when retain date is not expired' do
-      let(:date) { Date.today.prev_day(daily_retain_value - 1).to_s }
+    context 'when daily retain date is not expired' do
+      let(:days_ago) { daily_retain_value - 1 }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/lib/snapshot_manager/plan/pro/retention_validation_service_spec.rb
+++ b/spec/lib/snapshot_manager/plan/pro/retention_validation_service_spec.rb
@@ -1,28 +1,68 @@
 # frozen_string_literal: true
 
 require 'date'
+require 'timecop'
+
 require_relative '../../../../../lib/snapshot_manager/plan/pro/retention_validation_service'
 
 describe SnapshotManager::Plan::Pro::RetentionValidationService do
   describe '#call' do
     subject { described_class.new(date).call }
 
-    let(:months_ago) { Date.today.prev_month(monthly_retain_value) }
+    let(:date_today_months_ago) { Date.today.prev_month(monthly_retain_value) }
+    let(:years_ago) { date_today_months_ago.year }
+    let(:months_ago) { date_today_months_ago.month }
+    let(:days_ago) { last_day_of_the_month }
+    let(:date) { Date.new(years_ago, months_ago, days_ago).to_s }
 
-    context 'when retain date is expired' do
-      let(:date) { months_ago.prev_day(daily_retain_value + 1).to_s }
+    context 'when daily retain date is expired' do
+      context 'it returns false for retention validation' do
+        let(:date) { Date.today.prev_day(daily_retain_value + 1).to_s }
 
-      it { is_expected.to be_falsey }
+        it { is_expected.to be_falsey }
+      end
+
+      context 'and monthly retain date is not expired and maximum retain limit' do
+        it { is_expected.to be_truthy }
+      end
+
+      context 'and monthly retain date is not expired' do
+        let(:months_ago) { date_today_months_ago.month + 1 }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'and february retain date is not expired' do
+        let(:date) { '2022/02/28' }
+
+        before { Timecop.freeze(Date.new(2023, 2, 4)) }
+        after { Timecop.return }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'and monthly retain date is expired' do
+        let(:months_ago) { date_today_months_ago.month - 1 }
+
+        it { is_expected.to be_falsey }
+
+        context 'by not being the last day of the month' do
+          let(:months_ago) { date_today_months_ago.month }
+          let(:days_ago) { last_day_of_the_month - 1 }
+
+          it { is_expected.to be_falsey }
+        end
+      end
     end
 
-    context 'when retain date is today' do
-      let(:date) { months_ago.prev_day(daily_retain_value).to_s }
+    context 'when daily retain date is today' do
+      let(:date) { Date.today.prev_day(daily_retain_value).to_s }
 
       it { is_expected.to be_truthy }
     end
 
-    context 'when retain date is not expired' do
-      let(:date) { months_ago.prev_day(daily_retain_value - 1).to_s }
+    context 'when daily retain date is not expired' do
+      let(:date) { Date.today.prev_day(daily_retain_value - 1).to_s }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/lib/snapshot_manager/plan/ultra/retention_validation_service_spec.rb
+++ b/spec/lib/snapshot_manager/plan/ultra/retention_validation_service_spec.rb
@@ -1,30 +1,106 @@
 # frozen_string_literal: true
 
 require 'date'
+require 'timecop'
+
 require_relative '../../../../../lib/snapshot_manager/plan/ultra/retention_validation_service'
 
 describe SnapshotManager::Plan::Ultra::RetentionValidationService do
   describe '#call' do
     subject { described_class.new(date).call }
 
-    let(:years_and_months_ago) do
-      Date.today.prev_year(yearly_retain_value).prev_month(monthly_retain_value)
+    let(:date_today_months_ago) { Date.today.prev_month(monthly_retain_value) }
+    let(:years_ago) { date_today_months_ago.year }
+    let(:months_ago) { date_today_months_ago.month }
+    let(:days_ago) { last_day_of_the_month }
+    let(:date) { Date.new(years_ago, months_ago, days_ago).to_s }
+
+    context 'when daily retain date is expired' do
+      context 'it returns false for retention validation' do
+        let(:date) { Date.today.prev_day(daily_retain_value + 1).to_s }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'and monthly retain date is not expired and maximum retain limit' do
+        it { is_expected.to be_truthy }
+      end
+
+      context 'and monthly retain date is not expired' do
+        let(:months_ago) { date_today_months_ago.month + 1 }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'and february retain date is not expired' do
+        let(:date) { '2022/02/28' }
+
+        before { Timecop.freeze(Date.new(2023, 2, 4)) }
+        after { Timecop.return }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'and monthly retain date is expired' do
+        let(:months_ago) { date_today_months_ago.month - 1 }
+
+        it { is_expected.to be_falsey }
+
+        context 'by not being the last day of the month' do
+          let(:months_ago) { date_today_months_ago.month }
+          let(:days_ago) { last_day_of_the_month - 1 }
+
+          it { is_expected.to be_falsey }
+        end
+
+        context 'and yearly retain date is not expired and maximum retain limit' do
+          let(:date_today_years_ago) { Date.today.prev_year(yearly_retain_value) }
+          let(:years_ago) { date_today_years_ago.year }
+          let(:date) { Date.new(years_ago, 12, last_day_of_the_month).to_s }
+
+          it { is_expected.to be_truthy }
+        end
+
+        context 'and yearly retain date is not expired' do
+          let(:date_today_years_ago) { Date.today.prev_year(yearly_retain_value) }
+          let(:years_ago) { date_today_years_ago.year + 1 }
+          let(:date) { Date.new(years_ago, 12, last_day_of_the_month).to_s }
+
+          it { is_expected.to be_truthy }
+        end
+
+        context 'and yearly retain date is expired' do
+          let(:date_today_years_ago) { Date.today.prev_year(yearly_retain_value) }
+          let(:years_ago) { date_today_years_ago.year - 1 }
+          let(:days_ago) { last_day_of_the_month }
+          let(:date) { Date.new(years_ago, 12, days_ago).to_s }
+
+          it { is_expected.to be_falsey }
+
+          context 'by not being the last day of the year' do
+            let(:years_ago) { date_today_years_ago.year }
+            let(:days_ago) { last_day_of_the_month - 1 }
+
+            it { is_expected.to be_falsey }
+          end
+
+          context 'by not being the last month of the year' do
+            let(:date) { Date.new(years_ago, 11, days_ago).to_s }
+
+            it { is_expected.to be_falsey }
+          end
+        end
+      end
     end
 
-    context 'when retain date is expired' do
-      let(:date) { years_and_months_ago.prev_day(daily_retain_value + 1).to_s }
-
-      it { is_expected.to be_falsey }
-    end
-
-    context 'when retain date is today' do
-      let(:date) { years_and_months_ago.prev_day(daily_retain_value).to_s }
+    context 'when daily retain date is today' do
+      let(:date) { Date.today.prev_day(daily_retain_value).to_s }
 
       it { is_expected.to be_truthy }
     end
 
-    context 'when retain date is not expired' do
-      let(:date) { years_and_months_ago.prev_day(daily_retain_value - 1).to_s }
+    context 'when daily retain date is not expired' do
+      let(:date) { Date.today.prev_day(daily_retain_value - 1).to_s }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 def daily_retain_value = SnapshotManager::Plan::DAILY_RETAIN_VALUE
 def monthly_retain_value = SnapshotManager::Plan::MONTHLY_RETAIN_VALUE
 def yearly_retain_value = SnapshotManager::Plan::YEARLY_RETAIN_VALUE
+def last_day_of_the_month = SnapshotManager::Plan::LAST_DAY_OF_THE_MONTH
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
The Pro and Ultra Plans were not calculating correctly the retention validation for last of the month and last of the year.

This PR aims to flix the calculations, add more test cases and update README.

It also adds `timecop` gem to test static dates, as a test for February month is desirable for ending at a day with a value different from 30 or 31.